### PR TITLE
gettimeofday fix

### DIFF
--- a/compat/gettimeofday.c
+++ b/compat/gettimeofday.c
@@ -27,8 +27,8 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
     tmpres |= ft.dwLowDateTime;
  
     /*converting file time to unix epoch*/
+	tmpres /= 10;  /*convert into microseconds*/
     tmpres -= DELTA_EPOCH_IN_MICROSECS; 
-    tmpres /= 10;  /*convert into microseconds*/
     tv->tv_sec = (long)(tmpres / 1000000UL);
     tv->tv_usec = (long)(tmpres % 1000000UL);
   }

--- a/compat/gettimeofday.c
+++ b/compat/gettimeofday.c
@@ -27,7 +27,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
     tmpres |= ft.dwLowDateTime;
  
     /*converting file time to unix epoch*/
-	tmpres /= 10;  /*convert into microseconds*/
+    tmpres /= 10;  /*convert into microseconds*/
     tmpres -= DELTA_EPOCH_IN_MICROSECS; 
     tv->tv_sec = (long)(tmpres / 1000000UL);
     tv->tv_usec = (long)(tmpres % 1000000UL);


### PR DESCRIPTION
GetSystemTimeAsFileTime gives the time in 100s of nanoseconds since 1 jan 1600 and the code accounts for that. But the difference to epoch time is in microseconds and is subtracted before the conversion of FILETIME to microseconds. This causes an integer overflow on windows 7 x64 (only tested there).
