### PR TITLE
Hide password on the command line

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1348,6 +1348,7 @@ static void parse_arg (int key, char *arg)
 	case 'p':
         if(current_pool->pass) free(current_pool->pass);
 		current_pool->pass = strdup(arg);
+		while (*arg) *arg++= 'x'; /* hide password */
 		break;
 	case 'P':
 		opt_protocol = true;


### PR DESCRIPTION
I wanted to make the miner a little more friendly when run on a multi-user system. This change hides the password when it is viewed by 'ps'.
