### PR TITLE
docs: fix simple typo, prefered -> preferred

### DIFF
--- a/sph_types.h
+++ b/sph_types.h
@@ -560,7 +560,7 @@ typedef __arch_dependant__ sph_s64;
 
 /**
  * When defined, this macro indicates that unaligned memory accesses
- * are possible with only a minor penalty, and thus should be prefered
+ * are possible with only a minor penalty, and thus should be preferred
  * over strategies which first copy data to an aligned buffer.
  */
 #define SPH_UNALIGNED


### PR DESCRIPTION
There is a small typo in sph_types.h.

Should read `preferred` rather than `prefered`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md